### PR TITLE
Json Restruct (Danny's implementation)

### DIFF
--- a/scripts/analyzer/JsonRestruct.py
+++ b/scripts/analyzer/JsonRestruct.py
@@ -1,1 +1,60 @@
 """Danny's Approach to tidy Json data from both Chasten and Mutmut"""
+
+import json
+
+def restructure_json(chasten_data, mutmut_data):
+    structured_data = []
+
+    # Process Chasten results
+    for source in chasten_data['sources']:
+        source_file = source['filename']
+        check = source['check']  # Assuming there is only one check per source
+        for match in check['matches']:
+            pattern = {
+                'lineno': match['lineno'],
+                'coloffset': match['coloffset'],
+                'linematch': match['linematch'],
+                'context': match['linematch_context'],
+                # Include additional fields
+                'min': check.get('min'),
+                'max': check.get('max'),
+                'pattern': check.get('pattern'),
+                'check_id': check.get('id'),
+                'check_name': check.get('name'),
+                'description': check.get('description'),
+            }
+            # Find corresponding mutmut mutants
+            mutants = []
+            for testcase in mutmut_data['testsuite'][0]['testcase']:
+                if testcase['file'].endswith(source_file.split('/')[-1]) and testcase['line'] == pattern['lineno']:
+                    mutant = {
+                        'name': testcase['name'],
+                        'line': testcase['line'],
+                        'description': testcase['system-out'],
+                        # Include failure information if present
+                        'failure': testcase.get('failure')
+                    }
+                    mutants.append(mutant)
+
+            structured_data.append({
+                'file': source_file,
+                'pattern': pattern,
+                'mutants': mutants,
+            })
+
+    return structured_data
+
+def main():
+    with open('combined_result.json') as f:
+        data = json.load(f)
+
+    chasten_result = data['chasten_result']
+    mutmut_result = data['mutmut_result']
+
+    structured_result = restructure_json(chasten_result, mutmut_result)
+
+    with open('restructured_result.json', 'w') as f:
+        json.dump(structured_result, f, indent=2)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/analyzer/JsonRestruct.py
+++ b/scripts/analyzer/JsonRestruct.py
@@ -1,5 +1,4 @@
 """Danny's Approach to tidy Json data from both Chasten and Mutmut"""
-
 import json
 
 def restructure_json(chasten_data, mutmut_data):

--- a/scripts/analyzer/JsonRestruct.py
+++ b/scripts/analyzer/JsonRestruct.py
@@ -1,0 +1,1 @@
+"""Danny's Approach to tidy Json data from both Chasten and Mutmut"""


### PR DESCRIPTION
This implementation exists in branch `Json_tidyData`, using Danny's implementation to organize results from both `chasten` and `mutmut`.

As of right now `analyzer` is storing the result in a file called `combined_result.json` which saves `chasten` and `mutmut` results as below: 

`
|all of chasten result|
|all of mutmut result|
`

This file is not very convenient when analyzing and correlating the patterns and mutation. Therefore, @Danniyb utilized iteration to restructure a json file as below:

`
|chasten pattern 1|
|mutation pattern 1|

|chasten pattern 2|
|mutation pattern 2|
...
`
The code for this exists in a file named `jsonRestruct.py` and produces a separate json file `restructured_result.json` after executing the command `python jsonRestruct.py`. Here is a screenshot of the output

<img width="1186" alt="Screenshot 2024-02-26 at 11 13 48 AM" src="https://github.com/AstuteSource/SEERS/assets/84902170/61f0ac4b-0d9b-415d-a65b-46539a7486c9">


The next step for this implementation is integrating it with `analyzer` and producing it automatically after running `poetry run analyzer`